### PR TITLE
Fix chat message update after reset

### DIFF
--- a/Apple Intelligence Chat/ContentView.swift
+++ b/Apple Intelligence Chat/ContentView.swift
@@ -242,9 +242,10 @@ struct ContentView: View {
     private func stopStreaming() {
         streamingTask?.cancel()
     }
-    
+
     @MainActor
     private func updateLastMessage(with text: String) {
+        guard !messages.isEmpty else { return }
         messages[messages.count - 1].text = text
     }
     


### PR DESCRIPTION
## Summary
- prevent crash in chat when updating message list after reset

## Testing
- `swiftc "Apple Intelligence Chat/ContentView.swift" -o /tmp/out` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6849aebec4448320949a3f931bb70112